### PR TITLE
Update README.md link to session

### DIFF
--- a/ops30/README.md
+++ b/ops30/README.md
@@ -37,7 +37,7 @@ code.
 
 - This guide
 - PowerPoint presentation including notes for each slide [here](./presentations.md)
-- Full-length recording of presentation [Ignite Orlando recording](https://myignite.techcommunity.microsoft.com/sessions?q=OPS30)
+- Full-length recording of presentation [Ignite Orlando recording](https://myignite.techcommunity.microsoft.com/sessions/82998)
 - Director Cut Full-length recording of presentation  COMING SOON
 - Individual recordings of stage-ready hands-on demos (embedded in [slide deck](./presentations.md)), explanation videos listed above.
 


### PR DESCRIPTION
Link - https://myignite.techcommunity.microsoft.com/sessions?q=OPS30 is giving me file not found on Microsoft Edge dev browser.  I think q=OPS30 is pointing to sessions//82998**8**
Note the extra 8

link https://myignite.techcommunity.microsoft.com/sessions/82998 seems to work.

other option is to fix q=OPS30 to point to session id 82998 